### PR TITLE
Add support for setting and getting Z-Wave Device parameters via the ISY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG - HACS Version of ISY994 Component
 
+## [3.0.0.dev17] - Add Z-Wave Parameter Support
+
+- Add the following services to allow setting and getting Z-Wave Device parameters via the ISY.
+    - `isy994.get_zwave_parameter` - Call the service with the entity ID and parameter number to retreive. The parameter will be returned as an entity state attribute.
+    - `isy994.set_zwave_parameter` - Call the service with the entity ID, parameter number, value, and size in bytes and the ISY will set the parameter.
+
 ## [3.0.0dev16] - Bump PyISY, Minor stability updates
 
 - Bump PyISY-beta to 3.0.0dev16.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add the following services to allow setting and getting Z-Wave Device parameters via the ISY.
     - `isy994.get_zwave_parameter` - Call the service with the entity ID and parameter number to retreive. The parameter will be returned as an entity state attribute.
     - `isy994.set_zwave_parameter` - Call the service with the entity ID, parameter number, value, and size in bytes and the ISY will set the parameter.
+- Add a `isy994.rename_node` service to update an entities name within the ISY. Note this does not automatically update the name of the entity in Home Assistant. If you call `isy994.reload`, the name will be updated in Home Assistant ONLY IF you have not customized the name previously.
 
 ## [3.0.0dev16] - Bump PyISY, Minor stability updates
 

--- a/custom_components/isy994/entity.py
+++ b/custom_components/isy994/entity.py
@@ -159,7 +159,7 @@ class ISYNodeEntity(ISYEntity):
     async def send_node_command(self, command):
         """Respond to an entity service command call."""
         if not hasattr(self._node, command):
-            _LOGGER.error(
+            _LOGGER.exception(
                 "Invalid Service Call %s for device %s", command, self.entity_id
             )
             return
@@ -170,11 +170,29 @@ class ISYNodeEntity(ISYEntity):
     ):
         """Respond to an entity service raw command call."""
         if not hasattr(self._node, "send_cmd"):
-            _LOGGER.error(
+            _LOGGER.exception(
                 "Invalid Service Call %s for device %s", command, self.entity_id
             )
             return
         await self._node.send_cmd(command, value, unit_of_measurement, parameters)
+
+    async def get_zwave_parameter(self, parameter):
+        """Repsond to an entity service command to request a Z-Wave device parameter from the ISY."""
+        if not hasattr(self._node, "protocol") or self._node.protocol != PROTO_ZWAVE:
+            _LOGGER.exception(
+                "Invalid Service Call, cannot request Z-Wave Parameter for non-Z-Wave device %s",
+                self.entity_id,
+            )
+        await self._node.get_zwave_parameter(parameter)
+
+    async def set_zwave_parameter(self, parameter, value, size):
+        """Repsond to an entity service command to set a Z-Wave device parameter via the ISY."""
+        if not hasattr(self._node, "protocol") or self._node.protocol != PROTO_ZWAVE:
+            _LOGGER.exception(
+                "Invalid Service Call, cannot request Z-Wave Parameter for non-Z-Wave device %s",
+                self.entity_id,
+            )
+        await self._node.set_zwave_parameter(parameter, value, size)
 
 
 class ISYProgramEntity(ISYEntity):

--- a/custom_components/isy994/entity.py
+++ b/custom_components/isy994/entity.py
@@ -11,6 +11,7 @@ from pyisy.helpers import NodeProperty
 
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.typing import Dict
 
@@ -159,8 +160,8 @@ class ISYNodeEntity(ISYEntity):
     async def send_node_command(self, command):
         """Respond to an entity service command call."""
         if not hasattr(self._node, command):
-            _LOGGER.exception(
-                "Invalid Service Call %s for device %s", command, self.entity_id
+            raise HomeAssistantError(
+                f"Invalid service call: {command} for device {self.entity_id}"
             )
             return
         await getattr(self._node, command)()
@@ -170,8 +171,8 @@ class ISYNodeEntity(ISYEntity):
     ):
         """Respond to an entity service raw command call."""
         if not hasattr(self._node, "send_cmd"):
-            _LOGGER.exception(
-                "Invalid Service Call %s for device %s", command, self.entity_id
+            raise HomeAssistantError(
+                f"Invalid service call: {command} for device {self.entity_id}"
             )
             return
         await self._node.send_cmd(command, value, unit_of_measurement, parameters)
@@ -179,18 +180,16 @@ class ISYNodeEntity(ISYEntity):
     async def get_zwave_parameter(self, parameter):
         """Repsond to an entity service command to request a Z-Wave device parameter from the ISY."""
         if not hasattr(self._node, "protocol") or self._node.protocol != PROTO_ZWAVE:
-            _LOGGER.exception(
-                "Invalid Service Call, cannot request Z-Wave Parameter for non-Z-Wave device %s",
-                self.entity_id,
+            raise HomeAssistantError(
+                f"Invalid service call: cannot request Z-Wave Parameter for non-Z-Wave device {self.entity_id}"
             )
         await self._node.get_zwave_parameter(parameter)
 
     async def set_zwave_parameter(self, parameter, value, size):
         """Repsond to an entity service command to set a Z-Wave device parameter via the ISY."""
         if not hasattr(self._node, "protocol") or self._node.protocol != PROTO_ZWAVE:
-            _LOGGER.exception(
-                "Invalid Service Call, cannot request Z-Wave Parameter for non-Z-Wave device %s",
-                self.entity_id,
+            raise HomeAssistantError(
+                f"Invalid service call: cannot set Z-Wave Parameter for non-Z-Wave device {self.entity_id}"
             )
         await self._node.set_zwave_parameter(parameter, value, size)
         await self._node.get_zwave_parameter(parameter)

--- a/custom_components/isy994/entity.py
+++ b/custom_components/isy994/entity.py
@@ -193,6 +193,11 @@ class ISYNodeEntity(ISYEntity):
                 self.entity_id,
             )
         await self._node.set_zwave_parameter(parameter, value, size)
+        await self._node.get_zwave_parameter(parameter)
+
+    async def rename_node(self, name):
+        """Repsond to an entity service command to rename a node on the ISY."""
+        await self._node.rename(name)
 
 
 class ISYProgramEntity(ISYEntity):

--- a/custom_components/isy994/manifest.json
+++ b/custom_components/isy994/manifest.json
@@ -2,7 +2,7 @@
   "domain": "isy994",
   "name": "Universal Devices ISY994",
   "documentation": "https://www.home-assistant.io/integrations/isy994",
-  "requirements": ["pyisy-beta==3.0.0dev15"],
+  "requirements": ["pyisy-beta==3.0.0.dev17"],
   "codeowners": ["@bdraco", "@shbatm"],
   "config_flow": true,
   "ssdp": [
@@ -11,5 +11,5 @@
       "deviceType": "urn:udi-com:device:X_Insteon_Lighting_Device:1"
     }
   ],
-  "version": "3.0.0dev16"
+  "version": "3.0.0.dev17"
 }

--- a/custom_components/isy994/manifest.json
+++ b/custom_components/isy994/manifest.json
@@ -2,7 +2,7 @@
   "domain": "isy994",
   "name": "Universal Devices ISY994",
   "documentation": "https://www.home-assistant.io/integrations/isy994",
-  "requirements": ["pyisy-beta==3.0.0.dev17"],
+  "requirements": ["pyisy-beta==3.0.0.dev18"],
   "codeowners": ["@bdraco", "@shbatm"],
   "config_flow": true,
   "ssdp": [
@@ -11,5 +11,5 @@
       "deviceType": "urn:udi-com:device:X_Insteon_Lighting_Device:1"
     }
   ],
-  "version": "3.0.0.dev17"
+  "version": "3.0.0.dev18"
 }

--- a/custom_components/isy994/services.py
+++ b/custom_components/isy994/services.py
@@ -51,6 +51,7 @@ SERVICE_SEND_RAW_NODE_COMMAND = "send_raw_node_command"
 SERVICE_SEND_NODE_COMMAND = "send_node_command"
 SERVICE_GET_ZWAVE_PARAMETER = "get_zwave_parameter"
 SERVICE_SET_ZWAVE_PARAMETER = "set_zwave_parameter"
+SERVICE_RENAME_NODE = "rename_node"
 
 # Services valid only for dimmable lights.
 SERVICE_SET_ON_LEVEL = "set_on_level"
@@ -121,6 +122,8 @@ SERVICE_SEND_RAW_NODE_COMMAND_SCHEMA = {
 SERVICE_SEND_NODE_COMMAND_SCHEMA = {
     vol.Required(CONF_COMMAND): vol.In(VALID_NODE_COMMANDS)
 }
+
+SERVICE_RENAME_NODE_SCHEMA = {vol.Required(CONF_NAME): cv.string}
 
 SERVICE_GET_ZWAVE_PARAMETER_SCHEMA = {vol.Required(CONF_PARAMETER): vol.Coerce(int)}
 
@@ -413,6 +416,18 @@ def async_setup_services(hass: HomeAssistantType):
         service=SERVICE_SET_ZWAVE_PARAMETER,
         schema=cv.make_entity_service_schema(SERVICE_SET_ZWAVE_PARAMETER_SCHEMA),
         service_func=_async_set_zwave_parameter,
+    )
+
+    async def _async_rename_node(call: ServiceCall):
+        await hass.helpers.service.entity_service_call(
+            async_get_platforms(hass, DOMAIN), SERVICE_RENAME_NODE, call
+        )
+
+    hass.services.async_register(
+        domain=DOMAIN,
+        service=SERVICE_RENAME_NODE,
+        schema=cv.make_entity_service_schema(SERVICE_RENAME_NODE_SCHEMA),
+        service_func=_async_rename_node,
     )
 
 

--- a/custom_components/isy994/services.py
+++ b/custom_components/isy994/services.py
@@ -49,15 +49,19 @@ INTEGRATION_SERVICES = [
 # Entity specific methods (valid for most Groups/ISY Scenes, Lights, Switches, Fans)
 SERVICE_SEND_RAW_NODE_COMMAND = "send_raw_node_command"
 SERVICE_SEND_NODE_COMMAND = "send_node_command"
+SERVICE_GET_ZWAVE_PARAMETER = "get_zwave_parameter"
+SERVICE_SET_ZWAVE_PARAMETER = "set_zwave_parameter"
 
 # Services valid only for dimmable lights.
 SERVICE_SET_ON_LEVEL = "set_on_level"
 SERVICE_SET_RAMP_RATE = "set_ramp_rate"
 
+CONF_PARAMETER = "parameter"
 CONF_PARAMETERS = "parameters"
 CONF_VALUE = "value"
 CONF_INIT = "init"
 CONF_ISY = "isy"
+CONF_SIZE = "size"
 
 VALID_NODE_COMMANDS = [
     "beep",
@@ -82,6 +86,7 @@ VALID_PROGRAM_COMMANDS = [
     "enable_run_at_startup",
     "disable_run_at_startup",
 ]
+VALID_PARAMETER_SIZES = ["1", 1, "2", 2, "4", 4]
 
 
 def valid_isy_commands(value: Any) -> str:
@@ -115,6 +120,14 @@ SERVICE_SEND_RAW_NODE_COMMAND_SCHEMA = {
 
 SERVICE_SEND_NODE_COMMAND_SCHEMA = {
     vol.Required(CONF_COMMAND): vol.In(VALID_NODE_COMMANDS)
+}
+
+SERVICE_GET_ZWAVE_PARAMETER_SCHEMA = {vol.Required(CONF_PARAMETER): vol.Coerce(int)}
+
+SERVICE_SET_ZWAVE_PARAMETER_SCHEMA = {
+    vol.Required(CONF_PARAMETER): vol.Coerce(int),
+    vol.Required(CONF_VALUE): vol.Coerce(int),
+    vol.Required(CONF_SIZE): vol.In(VALID_PARAMETER_SIZES),
 }
 
 SERVICE_SET_VARIABLE_SCHEMA = vol.All(
@@ -376,6 +389,30 @@ def async_setup_services(hass: HomeAssistantType):
         service=SERVICE_SEND_NODE_COMMAND,
         schema=cv.make_entity_service_schema(SERVICE_SEND_NODE_COMMAND_SCHEMA),
         service_func=_async_send_node_command,
+    )
+
+    async def _async_get_zwave_parameter(call: ServiceCall):
+        await hass.helpers.service.entity_service_call(
+            async_get_platforms(hass, DOMAIN), SERVICE_GET_ZWAVE_PARAMETER, call
+        )
+
+    hass.services.async_register(
+        domain=DOMAIN,
+        service=SERVICE_GET_ZWAVE_PARAMETER,
+        schema=cv.make_entity_service_schema(SERVICE_GET_ZWAVE_PARAMETER_SCHEMA),
+        service_func=_async_get_zwave_parameter,
+    )
+
+    async def _async_set_zwave_parameter(call: ServiceCall):
+        await hass.helpers.service.entity_service_call(
+            async_get_platforms(hass, DOMAIN), SERVICE_SET_ZWAVE_PARAMETER, call
+        )
+
+    hass.services.async_register(
+        domain=DOMAIN,
+        service=SERVICE_SET_ZWAVE_PARAMETER,
+        schema=cv.make_entity_service_schema(SERVICE_SET_ZWAVE_PARAMETER_SCHEMA),
+        service_func=_async_set_zwave_parameter,
     )
 
 

--- a/custom_components/isy994/services.yaml
+++ b/custom_components/isy994/services.yaml
@@ -32,6 +32,34 @@ send_node_command:
     command:
       description: The command to be sent to the device.
       example: "fast_on"
+get_zwave_parameter:
+  description: >-
+    Request a Z-Wave Device parameter via the ISY. The parameter value will be returned as a entity state attribute with the name "ZW_#"
+    where "#" is the parameter number.
+  fields:
+    entity_id:
+      description: Name of an entity from which to retreive the parameter.
+      example: "light.front_door"
+    parameter:
+      description: The parameter number to retrieve from the device.
+      example: 8
+set_zwave_parameter:
+  description: >-
+    Update a Z-Wave Device parameter via the ISY. The parameter value will also be returned as a entity state attribute with the name "ZW_#"
+    where "#" is the parameter number.
+  fields:
+    entity_id:
+      description: Name of an entity on which to set the parameter.
+      example: "light.front_door"
+    parameter:
+      description: The parameter number to set on the end device.
+      example: 8
+    value:
+      description: The value to set for the parameter. May be an integer or byte string (e.g. "0xFFFF").
+      example: 33491663
+    size:
+      description: The size of the parameter, either 1, 2, or 4 bytes.
+      example: 4
 set_on_level:
   description: Send a ISY set_on_level command to a Node.
   fields:

--- a/custom_components/isy994/services.yaml
+++ b/custom_components/isy994/services.yaml
@@ -60,6 +60,18 @@ set_zwave_parameter:
     size:
       description: The size of the parameter, either 1, 2, or 4 bytes.
       example: 4
+rename_node:
+  description: >-
+    Rename a node or group (scene) on the ISY994. Note: this will not automatically change the Home Assistant Entity Name or Entity ID to match.
+    The entity name and ID will only be updated after calling `isy994.reload` or restarting Home Assistant, and ONLY IF you have not already customized the
+    name within Home Assistant.
+  fields:
+    entity_id:
+      description: Name of a Home Assistant entity to update the name in the ISY994.
+      example: "light.front_door"
+    name:
+      description: The new name to use within the ISY994.
+      example: "Front Door Light"
 set_on_level:
   description: Send a ISY set_on_level command to a Node.
   fields:


### PR DESCRIPTION
Add `isy994` services for setting and getting Z-Wave Device Parameters as well as renaming nodes on the ISY (v5.2.0 or later).

- `isy994.get_zwave_parameter`
- `isy994.set_zwave_parameter`
- `isy994.rename_node`

Fixes #70. Fixes #75.
Reference: automicus/PyISY#140, automicus/PyISY#155

CC: @bdraco, @MechEng70, @maverick2041