### PR TITLE
Use folder property from updated PyISY to populate suggested area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,18 @@
 # CHANGELOG - HACS Version of ISY994 Component
 
+## [3.0.0.dev19] - Add Suggested Area Support
+
+- Uses the folders on the ISY to suggest the areas for Home Assistant to use for each device.
+
+## [3.0.0.dev18] - Add support for renaming ISY Nodes from Home Assistant services
+
+- Add a `isy994.rename_node` service to update an entities name within the ISY. Note this does not automatically update the name of the entity in Home Assistant. If you call `isy994.reload`, the name will be updated in Home Assistant ONLY IF you have not customized the name previously.
+
 ## [3.0.0.dev17] - Add Z-Wave Parameter Support
 
 - Add the following services to allow setting and getting Z-Wave Device parameters via the ISY.
     - `isy994.get_zwave_parameter` - Call the service with the entity ID and parameter number to retreive. The parameter will be returned as an entity state attribute.
     - `isy994.set_zwave_parameter` - Call the service with the entity ID, parameter number, value, and size in bytes and the ISY will set the parameter.
-- Add a `isy994.rename_node` service to update an entities name within the ISY. Note this does not automatically update the name of the entity in Home Assistant. If you call `isy994.reload`, the name will be updated in Home Assistant ONLY IF you have not customized the name previously.
 
 ## [3.0.0dev16] - Bump PyISY, Minor stability updates
 

--- a/custom_components/isy994/entity.py
+++ b/custom_components/isy994/entity.py
@@ -103,6 +103,8 @@ class ISYEntity(Entity):
                     f"ProductTypeID:{node.zwave_props.prod_type_id} "
                     f"ProductID:{node.zwave_props.product_id}"
                 )
+        if hasattr(node, "folder") and node.folder is not None:
+            device_info["suggested_area"] = node.folder
         # Note: sw_version is not exposed by the ISY for the individual devices.
 
         return device_info

--- a/custom_components/isy994/manifest.json
+++ b/custom_components/isy994/manifest.json
@@ -2,7 +2,7 @@
   "domain": "isy994",
   "name": "Universal Devices ISY994",
   "documentation": "https://www.home-assistant.io/integrations/isy994",
-  "requirements": ["pyisy-beta==3.0.0.dev18"],
+  "requirements": ["pyisy-beta==3.0.0.dev19"],
   "codeowners": ["@bdraco", "@shbatm"],
   "config_flow": true,
   "ssdp": [
@@ -11,5 +11,5 @@
       "deviceType": "urn:udi-com:device:X_Insteon_Lighting_Device:1"
     }
   ],
-  "version": "3.0.0.dev18"
+  "version": "3.0.0.dev19"
 }


### PR DESCRIPTION
Implemented `suggested_area`

If the device is not in a folder, we do not set the field.

Closes #82. Closes #83.