### PR TITLE
Core Catchup to Current Dev Branch (2021-05-21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,11 +25,12 @@
     - Integrations i* - m*: Rename HomeAssistantType to HomeAssistant. (home-assistant/core#49586)
     - Reduce config entry setup/unload boilerplate G-J (home-assistant/core#49737)
     - Enable mccabe complexity checks in flake8 (home-assistant/core#49616)
+    - Add dhcp discovery support to isy994 (home-assistant/core#50488)
+    - Ensure isy994 is only discovered once (home-assistant/core#50577)
+- Core Catchup to `dev` branch as of 2021-05-17:
     - Use AddEntitiesCallback type, pt.2 (home-assistant/core#49921)
     - Clean up connection classes in integrations H-L (home-assistant/core#49891)
     - Migrate to async_get_current_platform everywhere (home-assistant/core#50034)
-    - Add dhcp discovery support to isy994 (home-assistant/core#50488)
-    - Ensure isy994 is only discovered once (home-assistant/core#50577)
     - Add targets and selectors for services (I-K) (home-assistant/core#50542)
 
 ## [3.0.0.dev19] - Add Suggested Area Support

--- a/custom_components/isy994/manifest.json
+++ b/custom_components/isy994/manifest.json
@@ -15,5 +15,5 @@
     {"hostname":"isy*", "macaddress":"0021B9*"}
   ],
   "iot_class": "local_push",
-  "version": "3.0.0"
+  "version": "3.0.1beta0"
 }

--- a/custom_components/isy994/manifest.json
+++ b/custom_components/isy994/manifest.json
@@ -2,6 +2,7 @@
   "domain": "isy994",
   "name": "Universal Devices ISY994",
   "documentation": "https://www.home-assistant.io/integrations/isy994",
+  "issue_tracker": "https://github.com/shbatm/hacs-isy994/issues",
   "requirements": ["pyisy==3.0.0"],
   "codeowners": ["@bdraco", "@shbatm"],
   "config_flow": true,

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "Universal Devices ISY994",
-  "homeassistant": "2021.5.4",
+  "homeassistant": "2021.6.0b0",
   "render_readme": true
 }


### PR DESCRIPTION
Core Catchup to dev branch as of 2021-05-17:

- Use AddEntitiesCallback type, pt.2 (home-assistant/core#49921)
- Clean up connection classes in integrations H-L (home-assistant/core#49891)
- Migrate to async_get_current_platform everywhere (home-assistant/core#50034)
- Add targets and selectors for services (I-K) (home-assistant/core#50542)