### PR TITLE
Migrate to pyisyox, remove device state attributes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,11 +52,10 @@ repos:
         stages: [manual]
       - id: check-json
         exclude: (.vscode|.devcontainer)
-        # - id: no-commit-to-branch
-        #   args:
-        #     - --branch=dev
-        #     - --branch=master
-        #     - --branch=rc
+      - id: no-commit-to-branch
+        args:
+          - --branch=dev
+          - --branch=main
   - repo: https://github.com/adrienverge/yamllint.git
     rev: v1.28.0
     hooks:
@@ -65,32 +64,3 @@ repos:
     rev: v2.7.1
     hooks:
       - id: prettier
-  - repo: https://github.com/cdce8p/python-typing-update
-    rev: v0.5.0
-    hooks:
-      # Run `python-typing-update` hook manually from time to time
-      # to update python typing syntax.
-      # Will require manual work, before submitting changes!
-      # pre-commit run --hook-stage manual python-typing-update --all-files
-      - id: python-typing-update
-        stages: [manual]
-        args:
-          - --py39-plus
-          - --force
-          - --keep-updates
-        files: ^(homeassistant|tests|script)/.+\.py$
-  - repo: local
-    hooks:
-      - id: pylint
-        name: pylint
-        entry: python3 -m pylint -j 0
-        language: system
-        types: [python]
-        files: ^pyisy/.+\.py$
-        args: ["-rn", "-sn"]
-      - id: mypy
-        name: mypy
-        entry: mypy
-        language: system
-        types: [python]
-        files: ^pyisy\/.+.py$

--- a/custom_components/isy994/__init__.py
+++ b/custom_components/isy994/__init__.py
@@ -6,10 +6,14 @@ from urllib.parse import urlparse
 
 from aiohttp import CookieJar
 import async_timeout
-from pyisy import ISY, ISYResponseParseError
-from pyisy.connection import ISYConnectionError, ISYConnectionInfo, ISYInvalidAuthError
-from pyisy.constants import CONFIG_NETWORKING
-from pyisy.networking import NetworkCommand
+from pyisyox import ISY, ISYResponseParseError
+from pyisyox.connection import (
+    ISYConnectionError,
+    ISYConnectionInfo,
+    ISYInvalidAuthError,
+)
+from pyisyox.constants import CONFIG_NETWORKING
+from pyisyox.networking import NetworkCommand
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -82,7 +86,7 @@ async def async_setup_entry(
         CONF_VAR_SENSOR_STRING, DEFAULT_VAR_SENSOR_STRING
     )
     enable_variables = isy_options.get(CONF_ENABLE_VARIABLES, True)
-    enable_nodeservers = isy_options.get(CONF_ENABLE_NODESERVERS, False)
+    enable_nodeservers = isy_options.get(CONF_ENABLE_NODESERVERS, True)
     enable_programs = isy_options.get(CONF_ENABLE_PROGRAMS, True)
     enable_networking = isy_options.get(CONF_ENABLE_NETWORKING, True)
 

--- a/custom_components/isy994/binary_sensor.py
+++ b/custom_components/isy994/binary_sensor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from typing import Any
 
-from pyisy.constants import (
+from pyisyox.constants import (
     CMD_OFF,
     CMD_ON,
     COMMAND_FRIENDLY_NAME,
@@ -12,8 +12,8 @@ from pyisy.constants import (
     PROP_STATUS,
     Protocol,
 )
-from pyisy.helpers.models import NodeProperty
-from pyisy.nodes import Node
+from pyisyox.helpers.models import NodeProperty
+from pyisyox.nodes import Node
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -533,9 +533,7 @@ class ISYBinarySensorHeartbeat(ISYNodeEntity, BinarySensorEntity, RestoreEntity)
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Get the state attributes for the device."""
-        attr = super().extra_state_attributes
-        attr["parent_entity_id"] = self._parent_device.entity_id
-        return attr
+        return {"parent_entity_id": self._parent_device.entity_id}
 
 
 class ISYBinarySensorProgramEntity(ISYProgramEntity, BinarySensorEntity):

--- a/custom_components/isy994/binary_sensor.py
+++ b/custom_components/isy994/binary_sensor.py
@@ -216,7 +216,7 @@ async def async_setup_entry(
     for node, control in isy_data.aux_properties[Platform.BINARY_SENSOR]:
         _LOGGER.debug("Loading %s %s", node.name, COMMAND_FRIENDLY_NAME.get(control))
         entity = ISYBinarySensorEntity(
-            node=node, control=control, device_info=device_info
+            node=node, control=control, device_info=devices.get(node.primary_node)
         )
     async_add_entities(entities)
 

--- a/custom_components/isy994/button.py
+++ b/custom_components/isy994/button.py
@@ -1,18 +1,18 @@
 """Representation of ISY/IoX buttons."""
 from __future__ import annotations
 
-from pyisy import ISY
-from pyisy.constants import (
+from pyisyox import ISY
+from pyisyox.constants import (
     ATTR_ACTION,
     TAG_ADDRESS,
     TAG_ENABLED,
     NodeChangeAction,
     Protocol,
 )
-from pyisy.helpers.events import EventListener
-from pyisy.helpers.models import NodeProperty
-from pyisy.networking import NetworkCommand
-from pyisy.nodes import Node
+from pyisyox.helpers.events import EventListener
+from pyisyox.helpers.models import NodeProperty
+from pyisyox.networking import NetworkCommand
+from pyisyox.nodes import Node
 
 from homeassistant.components.button import ButtonEntity
 from homeassistant.config_entries import ConfigEntry

--- a/custom_components/isy994/climate.py
+++ b/custom_components/isy994/climate.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any, cast
 
-from pyisy.constants import (
+from pyisyox.constants import (
     CMD_CLIMATE_FAN_SETTING,
     CMD_CLIMATE_MODE,
     PROP_HEAT_COOL_STATE,
@@ -13,7 +13,7 @@ from pyisy.constants import (
     PROP_UOM,
     Protocol,
 )
-from pyisy.nodes import Node
+from pyisyox.nodes import Node
 
 from homeassistant.components.climate import (
     ATTR_TARGET_TEMP_HIGH,

--- a/custom_components/isy994/config_flow.py
+++ b/custom_components/isy994/config_flow.py
@@ -8,8 +8,8 @@ from urllib.parse import urlparse, urlunparse
 
 from aiohttp import CookieJar
 import async_timeout
-from pyisy import ISYResponseParseError
-from pyisy.connection import (
+from pyisyox import ISYResponseParseError
+from pyisyox.connection import (
     Connection,
     ISYConnectionError,
     ISYConnectionInfo,
@@ -325,7 +325,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             CONF_VAR_SENSOR_STRING, DEFAULT_VAR_SENSOR_STRING
         )
         enable_variables = options.get(CONF_ENABLE_VARIABLES, True)
-        enable_nodeservers = options.get(CONF_ENABLE_NODESERVERS, False)
+        enable_nodeservers = options.get(CONF_ENABLE_NODESERVERS, True)
         enable_programs = options.get(CONF_ENABLE_PROGRAMS, True)
         enable_networking = options.get(CONF_ENABLE_NETWORKING, True)
 

--- a/custom_components/isy994/const.py
+++ b/custom_components/isy994/const.py
@@ -1,7 +1,7 @@
 """Constants for the ISY Platform."""
 import logging
 
-from pyisy.constants import (
+from pyisyox.constants import (
     DEV_BL_ADDR,
     DEV_CMD_MEMORY_WRITE,
     PROP_ON_LEVEL,

--- a/custom_components/isy994/cover.py
+++ b/custom_components/isy994/cover.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 
 from typing import Any, cast
 
-from pyisy.nodes import Node
-from pyisy.programs import Program
+from pyisyox.nodes import Node
+from pyisyox.programs import Program
 
 from homeassistant.components.cover import (
     ATTR_POSITION,

--- a/custom_components/isy994/entity.py
+++ b/custom_components/isy994/entity.py
@@ -112,7 +112,7 @@ class ISYNodeEntity(ISYEntity):
             name = COMMAND_FRIENDLY_NAME.get(control, control).replace("_", " ").title()
 
         if not node.is_device_root:
-            name = f"{node.name} {name}"
+            name = f"{node.name} {name}" if name else node.name
             self._attr_has_entity_name = False
         else:
             self._attr_has_entity_name = True

--- a/custom_components/isy994/events.py
+++ b/custom_components/isy994/events.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from dataclasses import asdict
 
 from pyisyox import ISY
-from pyisyox.constants import NodeChangeAction
+from pyisyox.constants import NodeChangeAction, SystemStatus
 from pyisyox.helpers.models import EntityStatus, NodeChangedEvent, NodeProperty
 
 from homeassistant.core import HomeAssistant, callback
@@ -64,3 +64,10 @@ class IsyControllerEvents:
     def program_event_handler(self, event: EntityStatus) -> None:
         """Handle program control event sent from ISY."""
         self.hass.bus.async_fire("isy994_program_event", asdict(event))
+
+    @callback
+    def system_status_handler(self, event: SystemStatus) -> None:
+        """Handle a system status changed event sent ISY class."""
+        _LOGGER.debug("System status changed: %s", event.name.replace("_", " ").title())
+        # Future: this is a logging call for now. Future PR to add support for
+        # a entity representing the hub's current status (busy, safe-mode, idle).

--- a/custom_components/isy994/events.py
+++ b/custom_components/isy994/events.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 
 from dataclasses import asdict
 
-from pyisy import ISY
-from pyisy.constants import NodeChangeAction, SystemStatus
-from pyisy.helpers.models import EntityStatus, NodeChangedEvent, NodeProperty
+from pyisyox import ISY
+from pyisyox.constants import NodeChangeAction
+from pyisyox.helpers.models import EntityStatus, NodeChangedEvent, NodeProperty
 
 from homeassistant.core import HomeAssistant, callback
 import homeassistant.helpers.device_registry as dr
@@ -64,10 +64,3 @@ class IsyControllerEvents:
     def program_event_handler(self, event: EntityStatus) -> None:
         """Handle program control event sent from ISY."""
         self.hass.bus.async_fire("isy994_program_event", asdict(event))
-
-    @callback
-    def system_status_handler(self, event: SystemStatus) -> None:
-        """Handle a system status changed event sent ISY class."""
-        _LOGGER.debug("System status changed: %s", event.name.replace("_", " ").title())
-        # Future: this is a logging call for now. Future PR to add support for
-        # a entity representing the hub's current status (busy, safe-mode, idle).

--- a/custom_components/isy994/fan.py
+++ b/custom_components/isy994/fan.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 import math
 from typing import Any
 
-from pyisy.constants import Protocol
-from pyisy.nodes import Node
-from pyisy.programs import Program
+from pyisyox.constants import Protocol
+from pyisyox.nodes import Node
+from pyisyox.programs import Program
 
 from homeassistant.components.fan import FanEntity, FanEntityFeature
 from homeassistant.config_entries import ConfigEntry

--- a/custom_components/isy994/helpers.py
+++ b/custom_components/isy994/helpers.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from types import MappingProxyType
 from typing import Any, cast
 
-from pyisy.constants import (
+from pyisyox.constants import (
     BACKLIGHT_SUPPORT,
     CMD_BACKLIGHT,
     PROP_BUSY,
@@ -16,9 +16,9 @@ from pyisy.constants import (
     UOM_INDEX,
     Protocol,
 )
-from pyisy.nodes import Group, Node, Nodes
-from pyisy.programs import Programs
-from pyisy.variables import Variables
+from pyisyox.nodes import Group, Node, Nodes
+from pyisyox.programs import Programs
+from pyisyox.variables import Variables
 
 from homeassistant.const import ATTR_MANUFACTURER, ATTR_MODEL, Platform
 from homeassistant.helpers.entity import DeviceInfo
@@ -370,14 +370,13 @@ def _categorize_nodes(
             isy_data.groups.append(node)
             continue
 
-        if node.protocol in (Protocol.INSTEON, Protocol.NODE_SERVER):
-            for control in node.aux_properties:
-                if control in SKIP_AUX_PROPS:
-                    continue
-                platform = Platform.SENSOR
-                if node.aux_properties[control].uom in BINARY_SENSOR_UOMS:
-                    platform = Platform.BINARY_SENSOR
-                isy_data.aux_properties[platform].append((node, control))
+        for control in node.aux_properties:
+            if control in SKIP_AUX_PROPS:
+                continue
+            platform = Platform.SENSOR
+            if node.aux_properties[control].uom in BINARY_SENSOR_UOMS:
+                platform = Platform.BINARY_SENSOR
+            isy_data.aux_properties[platform].append((node, control))
 
         if sensor_identifier in path or sensor_identifier in node.name:
             # User has specified to treat this as a sensor. First we need to

--- a/custom_components/isy994/light.py
+++ b/custom_components/isy994/light.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any, cast
 
-from pyisy.nodes import Node
+from pyisyox.nodes import Node
 
 from homeassistant.components.light import ColorMode, LightEntity
 from homeassistant.config_entries import ConfigEntry
@@ -102,9 +102,7 @@ class ISYLightEntity(ISYNodeEntity, LightEntity, RestoreEntity):
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the light attributes."""
-        attribs = super().extra_state_attributes
-        attribs[ATTR_LAST_BRIGHTNESS] = self._last_brightness
-        return attribs
+        return {ATTR_LAST_BRIGHTNESS: self._last_brightness}
 
     async def async_added_to_hass(self) -> None:
         """Restore last_brightness on restart."""

--- a/custom_components/isy994/lock.py
+++ b/custom_components/isy994/lock.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from pyisy.nodes import Node
-from pyisy.programs import Program
+from pyisyox.nodes import Node
+from pyisyox.programs import Program
 
 from homeassistant.components.lock import LockEntity
 from homeassistant.config_entries import ConfigEntry

--- a/custom_components/isy994/manifest.json
+++ b/custom_components/isy994/manifest.json
@@ -4,7 +4,7 @@
   "integration_type": "hub",
   "documentation": "https://www.home-assistant.io/integrations/isy994",
   "issues": "http://github.com/shbatm/hacs-isy994",
-  "requirements": ["pyisy-beta==4.0.0a4"],
+  "requirements": ["pyisyox==1.0.0a2"],
   "codeowners": ["@bdraco", "@shbatm"],
   "config_flow": true,
   "ssdp": [
@@ -31,6 +31,6 @@
     }
   ],
   "iot_class": "local_push",
-  "loggers": ["pyisy"],
-  "version": "4.0.4"
+  "loggers": ["pyisyox"],
+  "version": "4.0.5"
 }

--- a/custom_components/isy994/models.py
+++ b/custom_components/isy994/models.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from pyisy import ISY
-from pyisy.constants import Protocol
-from pyisy.helpers.models import EntityStatus, NodeProperty
-from pyisy.networking import NetworkCommand
-from pyisy.nodes import Group, Node
-from pyisy.programs import Program
-from pyisy.variables import Variable
+from pyisyox import ISY
+from pyisyox.constants import Protocol
+from pyisyox.helpers.models import EntityStatus, NodeProperty
+from pyisyox.networking import NetworkCommand
+from pyisyox.nodes import Group, Node
+from pyisyox.programs import Program
+from pyisyox.variables import Variable
 
 from homeassistant.const import Platform
 from homeassistant.helpers.entity import DeviceInfo

--- a/custom_components/isy994/number.py
+++ b/custom_components/isy994/number.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from dataclasses import replace
 from typing import Any
 
-from pyisy.constants import (
+from pyisyox.constants import (
     ATTR_ACTION,
     CMD_BACKLIGHT,
     PROP_ON_LEVEL,
@@ -12,10 +12,10 @@ from pyisy.constants import (
     UOM_PERCENTAGE,
     NodeChangeAction,
 )
-from pyisy.helpers.events import ATTR_EVENT_INFO, EventListener, NodeChangedEvent
-from pyisy.helpers.models import NodeProperty
-from pyisy.nodes import Node
-from pyisy.variables import Variable
+from pyisyox.helpers.events import ATTR_EVENT_INFO, EventListener, NodeChangedEvent
+from pyisyox.helpers.models import NodeProperty
+from pyisyox.nodes import Node
+from pyisyox.variables import Variable
 
 from homeassistant.components.number import (
     NumberEntity,

--- a/custom_components/isy994/select.py
+++ b/custom_components/isy994/select.py
@@ -1,7 +1,7 @@
 """Support for ISY select entities."""
 from __future__ import annotations
 
-from pyisy.constants import (
+from pyisyox.constants import (
     ATTR_ACTION,
     BACKLIGHT_INDEX,
     CMD_BACKLIGHT,
@@ -13,9 +13,9 @@ from pyisy.constants import (
     UOM_TO_STATES,
     NodeChangeAction,
 )
-from pyisy.helpers.events import ATTR_EVENT_INFO, EventListener, NodeChangedEvent
-from pyisy.helpers.models import NodeProperty
-from pyisy.nodes import Node
+from pyisyox.helpers.events import ATTR_EVENT_INFO, EventListener, NodeChangedEvent
+from pyisyox.helpers.models import NodeProperty
+from pyisyox.nodes import Node
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.config_entries import ConfigEntry

--- a/custom_components/isy994/sensor.py
+++ b/custom_components/isy994/sensor.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from pyisy.constants import (
+from pyisyox.constants import (
     COMMAND_FRIENDLY_NAME,
     PROP_BATTERY_LEVEL,
     PROP_COMMS_ERROR,
@@ -15,8 +15,8 @@ from pyisy.constants import (
     PROP_STATUS,
     PROP_TEMPERATURE,
 )
-from pyisy.helpers.models import NodeProperty
-from pyisy.nodes import Node
+from pyisyox.helpers.models import NodeProperty
+from pyisyox.nodes import Node
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -53,7 +53,7 @@ AUX_DISABLED_BY_DEFAULT_EXACT = {
     PROP_STATUS,
 }
 
-# Reference pyisy.constants.COMMAND_FRIENDLY_NAME for API details.
+# Reference pyisyox.constants.COMMAND_FRIENDLY_NAME for API details.
 #   Note: "LUMIN"/Illuminance removed, some devices use non-conformant "%" unit
 #         "VOCLVL"/VOC removed, uses qualitative UOM not ug/m^3
 ISY_CONTROL_TO_DEVICE_CLASS = {
@@ -126,7 +126,7 @@ async def async_setup_entry(
             return (None, isy_states)
         if (
             uom == UOM_INDEX
-            and (node_def := node.get_node_server_def()) is not None
+            and (node_def := node.get_node_def()) is not None
             and (editor := node_def.status_editors.get(control))
         ):
             return (None, editor.values)

--- a/custom_components/isy994/sensor.py
+++ b/custom_components/isy994/sensor.py
@@ -159,9 +159,9 @@ async def async_setup_entry(
         description = SensorEntityDescription(
             key=f"{node}_{control}",
             device_class=device_class,
-            state_class=ISY_CONTROL_TO_STATE_CLASS.get(control),
             native_unit_of_measurement=native_uom,
             options=list(options_dict.values()) if options_dict else None,
+            state_class=ISY_CONTROL_TO_STATE_CLASS.get(control),
             suggested_display_precision=precision,
             entity_category=ISY_CONTROL_TO_ENTITY_CATEGORY.get(control),
             entity_registry_enabled_default=enabled_default,

--- a/custom_components/isy994/services.py
+++ b/custom_components/isy994/services.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from pyisy.constants import COMMAND_FRIENDLY_NAME
+from pyisyox.constants import COMMAND_FRIENDLY_NAME
 import voluptuous as vol
 
 from homeassistant.const import (

--- a/custom_components/isy994/switch.py
+++ b/custom_components/isy994/switch.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 
 from typing import Any, cast
 
-from pyisy.nodes import Group, Node
-from pyisy.nodes.nodebase import NodeBase
-from pyisy.programs import Program
+from pyisyox.nodes import Group, Node
+from pyisyox.nodes.nodebase import NodeBase
+from pyisyox.programs import Program
 
 from homeassistant.components.switch import (
     SwitchDeviceClass,

--- a/custom_components/isy994/system_health.py
+++ b/custom_components/isy994/system_health.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from pyisy import ISY
+from pyisyox import ISY
 
 from homeassistant.components import system_health
 from homeassistant.config_entries import ConfigEntry


### PR DESCRIPTION
BREAKING CHANGES:

- Uses new module name for rewritten module: pyisyox
- Device State Attributes have been removed for all nodes that just used the aux_properties. These are now their own sensors.
