### PR TITLE
fix(sensor): use UnitOfVolumeFlowRate enum for UOMs 130, 143, 144

### DIFF
--- a/custom_components/isy994/const.py
+++ b/custom_components/isy994/const.py
@@ -437,7 +437,7 @@ UOM_FRIENDLY_NAME = {
     "127": UnitOfPressure.MMHG,
     "128": "J",
     "129": "BMI",  # Body Mass Index
-    "130": f"{UnitOfVolume.LITERS}/{UnitOfTime.HOURS}",
+    "130": UnitOfVolumeFlowRate.LITERS_PER_HOUR,
     "131": SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     "132": "bpm",  # Breaths per minute
     "133": UnitOfFrequency.KILOHERTZ,
@@ -450,8 +450,8 @@ UOM_FRIENDLY_NAME = {
     "140": f"{UnitOfMass.MILLIGRAMS}/{UnitOfVolume.LITERS}",
     "141": "N",  # Netwon
     "142": f"{UnitOfVolume.GALLONS}/{UnitOfTime.SECONDS}",
-    "143": "gpm",  # Gallon per Minute
-    "144": "gph",  # Gallon per Hour
+    "143": UnitOfVolumeFlowRate.GALLONS_PER_MINUTE,
+    "144": UnitOfVolumeFlowRate.GALLONS_PER_HOUR,
 }
 
 UOM_TO_STATES: dict[str, dict[int, str | LockState]] = {


### PR DESCRIPTION
## Summary
- Swap string literals (`"L/h"` f-string, `"gpm"`, `"gph"`) for `UnitOfVolumeFlowRate.LITERS_PER_HOUR` / `GALLONS_PER_MINUTE` / `GALLONS_PER_HOUR` in `UOM_FRIENDLY_NAME` entries 130/143/144.
- Restores `VOLUME_FLOW_RATE` device class (and the derived `state_class`) for sensors with these UOMs.

## Why
`sensor.py:_check_volume_flow_rate_uom` validates the unit via `UOM_FRIENDLY_NAME.get(uom) in UnitOfVolumeFlowRate`. The `in` check on a `StrEnum` matches enum **members**, not values, so the literals failed and the device class was stripped to `None`. Mirrors the equivalent fix in core PR home-assistant/core#169017.

## Test plan
- [ ] Devcontainer: load the integration against a controller exposing a UOM 130/143/144 sensor and confirm the entity reports `device_class: volume_flow_rate` and a non-null `state_class`.
- [ ] `pre-commit run --all-files` clean.
- [ ] (Follow-up PR) snapshot tests once `test_sensor.py` is migrated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)